### PR TITLE
Update About Me Page Layout

### DIFF
--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -22,11 +22,31 @@ const { frontmatter } = Astro.props;
   <Breadcrumbs />
   <main id="main-content">
     <section id="about" class="prose mb-28 max-w-3xl prose-img:border-0">
-      <!--<h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>-->
-      <!--<slot />-->
+      <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
+      <slot />
+      <h2>Biography</h2>
+      <p>Placeholder text for biography.</p>
+      <details>
+        <summary>Skills</summary>
+        <p>Placeholder text for skills.</p>
+      </details>
+      <details>
+        <summary>Hobbies</summary>
+        <p>Placeholder text for hobbies.</p>
+      </details>
       <DeathPlan client:only="react" />
     </section>
   </main>
   <Player client:only="react" />
   <Footer />
 </Layout>
+
+<style>
+  details {
+    margin-bottom: 1rem;
+  }
+  summary {
+    font-weight: bold;
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
Updates the "About me" page layout with new content and interactive elements.

- Reintroduces the `<slot />` tag to allow for custom content insertion from `src/pages/about.md`.
- Adds a new biography section with a heading and placeholder text.
- Implements collapsible sections for skills and hobbies, each with a heading and placeholder content.
- Enhances visual appeal with custom CSS for the new collapsible sections, including styled `details` and `summary` tags.
- Retains existing components (`Header`, `Breadcrumbs`, `Footer`, `DeathPlan`, and `Player`) in the layout, ensuring essential site navigation and features remain accessible.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bxb100/bxb100.github.io?shareId=23bffbe8-3bf5-407c-ac99-5c58ac25adce).